### PR TITLE
Switch from pysimplegui to freesimplegui

### DIFF
--- a/autoortho/config_ui.py
+++ b/autoortho/config_ui.py
@@ -18,7 +18,7 @@ from packaging import version
 import logging
 log = logging.getLogger(__name__)
 
-import PySimpleGUI as sg
+import FreeSimpleGUI as sg
 
 import downloader
 from version import __version__

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 refuse
 psutil
-pysimplegui
+freesimplegui
 Flask
 flask-socketio
 eventlet

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ pluggy==1.2.0
     # via pytest
 psutil==5.9.2
     # via -r requirements.in
-pysimplegui==4.60.4
+freesimplegui>5
     # via -r requirements.in
 pytest==7.4.0
     # via -r requirements.in


### PR DESCRIPTION
Switch from PySimpleGUI to FreeSimpleGUI (https://github.com/spyoungtech/FreeSimpleGUI) to avoid licensing issues.