### PR TITLE
Add brew tap command to macos instructions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -79,7 +79,8 @@ cd autoortho && git checkout macos-0.7.2
 5. install python3.10 with command ``brew install python@3.10``.
 6. install jpeg-turbo with command ``brew install jpeg-turbo``.
 7. brew install tcl-tk with command ``brew install tcl-tk``.
-8. modify brew tcl-tk
+8. Run command `brew tap --force homebrew/core`.
+9. modify brew tcl-tk
 ```
 brew edit tcl-tk
 ```
@@ -111,12 +112,12 @@ After this hit ESC on your keyboard then type the following:
 
 Then hit enter
 
-9. reinstall tcl-tk with modified brew tcl-tk
+10. reinstall tcl-tk with modified brew tcl-tk
 ```shell
 HOMEBREW_NO_INSTALL_FROM_API=1 brew reinstall --build-from-source tcl-tk
 ```
-10. install python-tk with command ``brew install python-tk@3.10``.
-11. install python dependencies.
+11. install python-tk with command ``brew install python-tk@3.10``.
+12. install python dependencies.
 ```
 python3.10 -m pip install -U pip
 python3.10 -m pip install setuptools
@@ -124,11 +125,11 @@ python3.10 -m pip install wheel
 python3.10 -m pip install -r requirements-build.txt --no-use-pep517
 python3.10 -m pip install -r requirements.txt
 ```
-12. Remove any MacOS quarantine flags
+13. Remove any MacOS quarantine flags
 ``` shell
 sudo xattr -dr com.apple.quarantine *
 ```
-13. Run it
+14. Run it
 ``` shell
 python3.10 autoortho
 ```


### PR DESCRIPTION
This is required on newer homebrew installations due to the change to using the API by default - if it isn't run before the later build command, homebrew will tap core and clobber any changes made before that